### PR TITLE
Add basic CI

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -1,0 +1,19 @@
+name: "Java"
+
+on:
+    push:
+        branches:
+            - main
+    pull_request:
+        branches:
+            - main
+    workflow_dispatch:
+
+jobs:
+    build:
+        name: "Build"
+        runs-on: "ubuntu-latest"
+
+        steps:
+            - name: "Clone repository"
+              uses: actions/checkout@v4


### PR DESCRIPTION
Add script for Github action to simulate workflows automatically when events are triggered.
At the moment, it should only simulate cloning repository on a virtual ubuntu-latest environment.